### PR TITLE
Fix freeze when closing current tab

### DIFF
--- a/src/functions/background.js
+++ b/src/functions/background.js
@@ -75,13 +75,17 @@ chrome.runtime.onMessage.addListener(
 
             case 'closeCurrentTab': {
                 if (!sender.tab.pinned)
-                    chrome.tabs.remove(sender.tab.id, function () { });
+					setTimeout(function() {
+						chrome.tabs.remove(sender.tab.id);
+					}, 0);
             } break;
 
             case 'closeAllTabsExceptCurrent': {
                 chrome.tabs.query({ active: false, pinned: false, currentWindow: true }, function (tabs) {
                     tabs.forEach(function (tab) {
-                        chrome.tabs.remove(tab.id, function () { });
+						setTimeout(function() {
+							chrome.tabs.remove(tab.id);
+						}, 0);
                     })
                 });
             } break;
@@ -508,7 +512,9 @@ chrome.runtime.onMessage.addListener(
                 if (request.url !== null && request.url !== sender.tab.url)
                     chrome.windows.create({ "url": request.url });
                 else {
-                    chrome.tabs.remove(sender.tab.id, function () { });
+					setTimeout(function() {
+						chrome.tabs.remove(sender.tab.id);
+					}, 0);
 
                     chrome.windows.create({}, function (window) {
                         chrome.tabs.move(sender.tab.id, { index: 0, windowId: window.id });
@@ -605,7 +611,9 @@ chrome.runtime.onMessage.addListener(
             } break;
 
             case 'closeIndexedTab': {
-                chrome.tabs.remove(request.id, function () { });
+				setTimeout(function() {
+					chrome.tabs.remove(request.id);
+				}, 0);
             } break;
 
             case 'copyPrefetchedImageFirefox': {


### PR DESCRIPTION
Vivaldi sometimes takes a long time to execute the chrome.tabs.remove() function, and do not run it in parallel. Running this function asynchronously resolves the aforementioned freeze in https://github.com/emvaized/circle-mouse-gestures/issues/33.

[I have the same problem](https://github.com/PhilJbt/TabsTree/blob/7d46f78b77d609778764ebe58daa73172907bd57/src/sidebar.js#L1376-L1381) in a Chrome Extension I'm developing, and fixed it the same way.

To be sure, I built CMG myself with this fix, and it does not freeze anymore.